### PR TITLE
Add professional CV website

### DIFF
--- a/website/Jordan_Rivera_CV.pdf
+++ b/website/Jordan_Rivera_CV.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT
+/F1 24 Tf
+72 700 Td
+(Replace with your CV) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000114 00000 n 
+0000000267 00000 n 
+0000000396 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+479
+%%EOF

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Jordan Rivera &mdash; Product-Oriented ML Engineer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="container hero__inner">
+        <div class="hero__content">
+          <p class="eyebrow">Product-Focused Machine Learning Engineer</p>
+          <h1>Jordan Rivera</h1>
+          <p class="lead">
+            I design and ship responsible AI experiences that translate research
+            breakthroughs into measurable customer value. My approach blends deep
+            technical expertise with product strategy and empathetic leadership.
+          </p>
+          <div class="hero__actions">
+            <a class="button button--primary" href="#contact">Contact</a>
+            <a class="button button--ghost" href="Jordan_Rivera_CV.pdf"
+              >Download CV</a
+            >
+          </div>
+        </div>
+        <div class="hero__aside">
+          <div class="card hero__card">
+            <h2>At a glance</h2>
+            <ul>
+              <li><strong>10+</strong> years building ML products</li>
+              <li>Former lead @ <strong>VectorWorks Labs</strong></li>
+              <li>Top 2% Kaggle Competitor</li>
+              <li>Stanford MS &mdash; AI Systems</li>
+              <li>Based in San Francisco, CA</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section id="about" class="section">
+        <div class="container grid grid--2">
+          <div>
+            <h2>Guiding principles</h2>
+            <p>
+              I believe the most impactful ML products are rooted in authentic
+              customer needs, built iteratively with multidisciplinary teams, and
+              governed by a commitment to transparency and trust. I lead teams
+              that are comfortable operating across research, platform, and
+              product layers to deliver sustained value.
+            </p>
+          </div>
+          <div class="card">
+            <h3>Core competencies</h3>
+            <ul class="stacked-list">
+              <li>ML product strategy &amp; roadmap leadership</li>
+              <li>Generative AI safety, evaluation, and monitoring</li>
+              <li>Experimentation platforms &amp; data flywheels</li>
+              <li>Human-centered design for AI interactions</li>
+              <li>Cross-functional stakeholder influence</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="experience" class="section section--alt">
+        <div class="container">
+          <div class="section__header">
+            <h2>Experience</h2>
+            <p>High-impact roles where I grew products from concept to scale.</p>
+          </div>
+          <div class="timeline">
+            <article class="timeline__item">
+              <div class="timeline__meta">
+                <h3>Director of ML Platforms</h3>
+                <p class="timeline__company">VectorWorks Labs</p>
+                <span class="timeline__date">2020 &ndash; Present</span>
+              </div>
+              <div class="timeline__body">
+                <ul>
+                  <li>
+                    Led a 25-person org delivering an experimentation platform
+                    that reduced model deployment time by 60% and increased
+                    activation by 18%.
+                  </li>
+                  <li>
+                    Shipped trust dashboards with real-time drift monitoring,
+                    enabling enterprise adoption across 7 product lines.
+                  </li>
+                  <li>
+                    Partnered with design and policy to establish generative AI
+                    guardrails adopted as company-wide standard.
+                  </li>
+                </ul>
+              </div>
+            </article>
+            <article class="timeline__item">
+              <div class="timeline__meta">
+                <h3>Staff ML Engineer</h3>
+                <p class="timeline__company">Lumen Analytics</p>
+                <span class="timeline__date">2016 &ndash; 2020</span>
+              </div>
+              <div class="timeline__body">
+                <ul>
+                  <li>
+                    Built personalized recommendations powering a 3x revenue
+                    increase; system handled 15M daily events.
+                  </li>
+                  <li>
+                    Mentored engineers and data scientists, growing team from 4
+                    to 19 contributors.
+                  </li>
+                  <li>
+                    Co-authored company patent on adaptive feedback loops.
+                  </li>
+                </ul>
+              </div>
+            </article>
+            <article class="timeline__item">
+              <div class="timeline__meta">
+                <h3>ML Research Fellow</h3>
+                <p class="timeline__company">Stanford AI Lab</p>
+                <span class="timeline__date">2014 &ndash; 2016</span>
+              </div>
+              <div class="timeline__body">
+                <ul>
+                  <li>
+                    Published 5 papers on efficient transformer architectures
+                    and interpretable attention.
+                  </li>
+                  <li>
+                    Delivered invited talks at NeurIPS and ICML.
+                  </li>
+                </ul>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="projects" class="section">
+        <div class="container">
+          <div class="section__header">
+            <h2>Selected projects</h2>
+            <p>A sampling of work that demonstrates my range and depth.</p>
+          </div>
+          <div class="grid grid--3">
+            <article class="card project">
+              <h3>Resonance</h3>
+              <p>
+                Designed a human-in-the-loop content moderation system with
+                explainable model outputs that cut manual review time in half.
+              </p>
+              <ul class="tag-list">
+                <li>Responsible AI</li>
+                <li>Trust &amp; Safety</li>
+                <li>Design Systems</li>
+              </ul>
+            </article>
+            <article class="card project">
+              <h3>Atlas Embed</h3>
+              <p>
+                Productionized a cross-lingual embedding service powering
+                intelligent search in 27 languages, serving 120M requests/day.
+              </p>
+              <ul class="tag-list">
+                <li>Multilingual ML</li>
+                <li>Vector DBs</li>
+                <li>SRE</li>
+              </ul>
+            </article>
+            <article class="card project">
+              <h3>Pulse Forecast</h3>
+              <p>
+                Launched probabilistic forecasting models that improved
+                inventory accuracy by 24% and unlocked new enterprise tier.
+              </p>
+              <ul class="tag-list">
+                <li>Time Series</li>
+                <li>Bayesian ML</li>
+                <li>Product Analytics</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="skills" class="section section--alt">
+        <div class="container grid grid--2">
+          <div>
+            <h2>Skills snapshot</h2>
+            <ul class="stacked-list stacked-list--dense">
+              <li><strong>Languages:</strong> Python, TypeScript, SQL, Rust</li>
+              <li><strong>Frameworks:</strong> PyTorch, JAX, LangChain, React</li>
+              <li>
+                <strong>Platforms:</strong> AWS, GCP, Kubernetes, Feature Stores
+              </li>
+              <li><strong>Leadership:</strong> Hiring, OKRs, Mentorship</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Recognition</h3>
+            <ul class="stacked-list stacked-list--dense">
+              <li>Winner &mdash; Responsible AI Challenge 2023</li>
+              <li>IEEE Rising Star in AI (2021)</li>
+              <li>Author &mdash; "Operationalizing ML with Confidence" (O'Reilly)</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="section section--highlight">
+        <div class="container contact">
+          <div>
+            <h2>Let&rsquo;s build thoughtful AI together</h2>
+            <p>
+              I&rsquo;m actively partnering with teams shipping AI products in highly
+              regulated spaces. Reach out for speaking engagements, advisory, or
+              product collaborations.
+            </p>
+          </div>
+          <div class="contact__details">
+            <a href="mailto:jordan@rivera.ai">jordan@rivera.ai</a>
+            <a href="https://www.linkedin.com/in/jordanrivera" target="_blank"
+              >linkedin.com/in/jordanrivera</a
+            >
+            <a href="https://github.com/jordanrivera" target="_blank"
+              >github.com/jordanrivera</a
+            >
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container footer__inner">
+        <p>&copy; 2024 Jordan Rivera. All rights reserved.</p>
+        <div class="footer__links">
+          <a href="#about">About</a>
+          <a href="#experience">Experience</a>
+          <a href="#projects">Projects</a>
+          <a href="#contact">Contact</a>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,313 @@
+:root {
+  --bg: #f4f6fb;
+  --bg-alt: #ffffff;
+  --bg-highlight: #182848;
+  --text: #1f2a44;
+  --muted: #5a6482;
+  --accent: #3d7dff;
+  --accent-soft: rgba(61, 125, 255, 0.1);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  --shadow: 0 24px 60px rgba(15, 33, 86, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent);
+}
+
+h1,
+h2,
+h3 {
+  margin-top: 0;
+  color: var(--text);
+}
+
+h1 {
+  font-size: clamp(2.75rem, 5vw, 3.75rem);
+  line-height: 1.1;
+}
+
+h2 {
+  font-size: clamp(2rem, 3.5vw, 2.5rem);
+  margin-bottom: 0.75rem;
+}
+
+h3 {
+  font-size: 1.35rem;
+}
+
+p {
+  margin-top: 0;
+  color: var(--muted);
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.section {
+  padding: clamp(3rem, 5vw, 5rem) 0;
+}
+
+.section--alt {
+  background-color: var(--bg-alt);
+}
+
+.section--highlight {
+  background: linear-gradient(135deg, #182848, #4b6cb7);
+  color: #f8fbff;
+}
+
+.section--highlight p {
+  color: inherit;
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+}
+
+.grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.grid--2 {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.grid--3 {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.hero {
+  background: radial-gradient(circle at top right, #dfe7ff, #f4f6fb 60%);
+  padding-top: clamp(4rem, 8vw, 6rem);
+  padding-bottom: clamp(3rem, 5vw, 4rem);
+}
+
+.hero__inner {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: center;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-weight: 600;
+  color: var(--accent);
+  font-size: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.lead {
+  font-size: 1.1rem;
+  max-width: 60ch;
+}
+
+.hero__actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.75rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+  border: 1px solid transparent;
+}
+
+.button--primary {
+  background: var(--accent);
+  color: white;
+  box-shadow: var(--shadow);
+}
+
+.button--primary:hover,
+.button--primary:focus {
+  transform: translateY(-2px);
+}
+
+.button--ghost {
+  border-color: rgba(31, 42, 68, 0.15);
+  background-color: white;
+}
+
+.button--ghost:hover,
+.button--ghost:focus {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.card {
+  background-color: white;
+  padding: 2rem;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+}
+
+.hero__card ul {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.2rem;
+  list-style: disc;
+  color: var(--muted);
+}
+
+.stacked-list li + li {
+  margin-top: 0.75rem;
+}
+
+.stacked-list--dense li + li {
+  margin-top: 0.35rem;
+}
+
+.timeline {
+  display: grid;
+  gap: 2rem;
+}
+
+.timeline__item {
+  display: grid;
+  gap: 1rem;
+  padding: 2rem;
+  border-radius: var(--radius-lg);
+  background-color: white;
+  box-shadow: var(--shadow);
+}
+
+.timeline__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  align-items: baseline;
+}
+
+.timeline__company {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.timeline__date {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.timeline__body ul {
+  display: grid;
+  gap: 0.75rem;
+  color: var(--muted);
+}
+
+.project {
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+.tag-list li {
+  background-color: var(--accent-soft);
+  color: var(--accent);
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.contact {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.contact__details {
+  display: grid;
+  gap: 0.75rem;
+  font-weight: 600;
+}
+
+.contact__details a {
+  color: #f8fbff;
+}
+
+.footer {
+  padding: 2rem 0 3rem;
+  background-color: #0f1933;
+  color: #e3e8f6;
+}
+
+.footer__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.footer__links {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.footer__links a {
+  color: inherit;
+  font-weight: 500;
+}
+
+@media (min-width: 720px) {
+  .footer__inner {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .hero__card {
+    padding: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a polished single-page CV/profile site with dedicated sections for hero, experience, projects, skills, and contact
- implement modern responsive styling with typography, grids, and reusable components
- include a downloadable CV placeholder asset for quick updates

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e5a0d7ea74832f93da271b06aabed0